### PR TITLE
manifest: Fix URL template

### DIFF
--- a/org.freedesktop.Sdk.Extension.typescript.json
+++ b/org.freedesktop.Sdk.Extension.typescript.json
@@ -41,7 +41,7 @@
                         "type": "anitya",
                         "project-id": 13733,
                         "stable-only": true,
-                        "url-template": "https://github.com/microsoft/TypeScript/releases/download/$version/typescript-$version.tgz"
+                        "url-template": "https://github.com/microsoft/TypeScript/releases/download/v$version/typescript-$version.tgz"
                     }
                 }
             ]


### PR DESCRIPTION
We forgot a very important "v" in front of the version number.
