### PR TITLE
23.08 stable

### DIFF
--- a/org.freedesktop.Sdk.Extension.typescript.json
+++ b/org.freedesktop.Sdk.Extension.typescript.json
@@ -1,10 +1,10 @@
 {
     "id": "org.freedesktop.Sdk.Extension.typescript",
-    "branch": "23.08beta",
+    "branch": "23.08",
     "runtime": "org.freedesktop.Sdk",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "23.08beta",
+    "runtime-version": "23.08",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.node18"
     ],


### PR DESCRIPTION
Should be in a branch of its own, specifically one named `branch/23.08` - but I'm filing this so I can get a 23.08 stable extension to use with the GNOME nightly runtime.