### PR TITLE
Use 24.08 version of freedesktop-sdk

### DIFF
--- a/org.freedesktop.Sdk.Extension.typescript.json
+++ b/org.freedesktop.Sdk.Extension.typescript.json
@@ -1,15 +1,14 @@
 {
     "id": "org.freedesktop.Sdk.Extension.typescript",
-    "branch": "23.08",
+    "branch": "24.08",
     "runtime": "org.freedesktop.Sdk",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.node20"
     ],
     "separate-locales": false,
-    "appstream-compose": false,
     "build-options": {
         "prefix": "/usr/lib/sdk/typescript",
         "append-path": "/usr/lib/sdk/node20/bin"
@@ -90,8 +89,7 @@
             "buildsystem": "simple",
             "build-commands": [
                 "mkdir -p ${FLATPAK_DEST}/share/metainfo",
-                "cp org.freedesktop.Sdk.Extension.typescript.metainfo.xml ${FLATPAK_DEST}/share/metainfo",
-                "appstream-compose  --basename=org.freedesktop.Sdk.Extension.typescript --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.typescript"
+                "cp org.freedesktop.Sdk.Extension.typescript.metainfo.xml ${FLATPAK_DEST}/share/metainfo"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Fixes: https://github.com/flathub/org.freedesktop.Sdk.Extension.typescript/issues/29


The contents of the MR are in line with https://github.com/flathub/org.freedesktop.Sdk.Extension.node20/pull/11.